### PR TITLE
adding git installation so that python modules from github can be installed 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
+    git \
     libxrender1 \
     libexpat1 \
     libxext6 \


### PR DESCRIPTION

Correction in the Dockerfile by adding `git` as libraries to be installed. Otherwise, the last line in the `requirements.txt`, `git+https://github.com/BioDataFuse/pyBiodatafuse.git`, does not get installed. 