### PR TITLE
Spacing for links on tools page

### DIFF
--- a/static/css/tools.css
+++ b/static/css/tools.css
@@ -13,3 +13,7 @@
     border-radius: 8px; /* Optional: to match the card's rounded corners */
     object-fit: cover; /* Ensures the image fits nicely within the card */
 }
+
+.tools-links {
+    display: inline-block; /* Placing 2 links and seperator in one line */
+}

--- a/templates/services/service_list.html
+++ b/templates/services/service_list.html
@@ -12,8 +12,9 @@
               <div class="card-body">
                 <h2 class="card-title">{{ item.service }}</h2>
                 <p id="desc" class="card-text">{{ item.description }}</p>
-                <a href="{{ item.url }}" class="btn btn-outline-info">Service information</a>
-                <a href="{{ item.meta_data }}" class="btn btn-outline-info">Meta data</a>
+                <a class="tools-links" href="{{ item.url }}" class="btn btn-outline-info">Service information</a>
+                <h3 class="tools-links">&nbsp;&nbsp; - &nbsp;&nbsp;</h3>
+                <a class="tools-links" href="{{ item.meta_data }}" class="btn btn-outline-info">Meta data</a>
               </div>
             </div>
           {% else %}


### PR DESCRIPTION
Hey Mirthe and Ozan,

Sorry that it took a while to check out your work Mirthe, luckily Ozan had time to look at it.
Absolutely love the new look! Great work!

Couple suggestions:
- I've created this PR to fix the spacing for links on the services/tools cards on tools.html.
  Below pic shows it (the blue color of "meta data" is because of mouse-over, the print screen tool removes the mouse).
  Is this look fine? 
![Screenshot from 2025-05-12 11-00-23](https://github.com/user-attachments/assets/3e5bde29-999d-46f3-ba4f-6dd001b2fb45)

- On the main page the assessment, worksflows, tools and data buttons show the top of the hexagon below when you mouse-over (see first picture below)
![Screenshot from 2025-05-12 10-46-01](https://github.com/user-attachments/assets/d2c40135-1fec-431f-b2a4-79e4c1942231)

  My suggestion would be to use a box-shadow (see second picture below) 
![Screenshot from 2025-05-12 11-14-18](https://github.com/user-attachments/assets/e4a75d64-f44f-429f-b787-1bad98093f85)

Is that better? The code to implement this is not in this PR, waiting for opinions.

- The navigation bar no longer changes into a hamburger menu when zooming in/using mobile resolutions, is this something we want to fix or are we not bothering since it's unlikely the user uses the website on mobile?

This is the end of my nitpicking session, thank you for reading! 
Once again, great work Mirthe! 


